### PR TITLE
Fix bug where public property is treated as a getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ npm install --save-dev @nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs
           provider
         );
         // call the numAddressesWhitelisted from the contract
-        const _numberOfWhitelisted = await whitelistContract.numAddressesWhitelisted();
+        const _numberOfWhitelisted = await whitelistContract.numAddressesWhitelisted;
         setNumberOfWhitelisted(_numberOfWhitelisted);
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
This caused me the following error in the front end

TypeError: whitelistContract.numAddressesWhitelisted is not a function