### PR TITLE
Added instructions to add Whitelist-Dapp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Lets start building 🚀
 To build the smart contract we will be using [Hardhat](https://hardhat.org/).
 Hardhat is an Ethereum development environment and framework designed for full stack development in Solidity. In simple words you can write your smart contract, deploy them, run tests, and debug your code.
 
-- First, you need to create a Whitelist-Daap folder where the Hardhat project and your Next.js app will later go
-- Then, in Whitelist-Daap folder, you will set up Hardhat project, Open up a terminal and execute these commands
 
+
+ - First, you need to create a Whitelist-Daap folder where the Hardhat project and your Next.js app will later go
   ```bash
   mkdir Whitelist-Dapp
   cd Whitelist-Dapp
-  
+  ```
+ - Then, in Whitelist-Daap folder, you will set up Hardhat project, Open up a terminal and execute these commands
+  ```bash
   mkdir hardhat-tutorial
   cd hardhat-tutorial
   npm init --yes

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ Hardhat is an Ethereum development environment and framework designed for full s
 
 
  - First, you need to create a Whitelist-Daap folder where the Hardhat project and your Next.js app will later go
+ - Open up a terminal and execute these commands
   ```bash
   mkdir Whitelist-Dapp
   cd Whitelist-Dapp
   ```
- - Then, in Whitelist-Daap folder, you will set up Hardhat project, Open up a terminal and execute these commands
+ - Then, in Whitelist-Daap folder, you will set up Hardhat project 
   ```bash
   mkdir hardhat-tutorial
   cd hardhat-tutorial

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ Lets start building 🚀
 To build the smart contract we will be using [Hardhat](https://hardhat.org/).
 Hardhat is an Ethereum development environment and framework designed for full stack development in Solidity. In simple words you can write your smart contract, deploy them, run tests, and debug your code.
 
-- To setup a Hardhat project, Open up a terminal and execute these commands
+- First, you need to create a Whitelist-Daap folder where Hardhat project will go
+- Then, in that folder, you will set up Hardhat project, Open up a terminal and execute these commands
 
   ```bash
+  mkdir Whitelist-Dapp
+  cd Whitelist-Dapp
   mkdir hardhat-tutorial
   cd hardhat-tutorial
   npm init --yes

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Lets start building 🚀
 To build the smart contract we will be using [Hardhat](https://hardhat.org/).
 Hardhat is an Ethereum development environment and framework designed for full stack development in Solidity. In simple words you can write your smart contract, deploy them, run tests, and debug your code.
 
-- First, you need to create a Whitelist-Daap folder where Hardhat project will go
+- First, you need to create a Whitelist-Daap folder where the Hardhat project and your Next.js app will later go
 - Then, in that folder, you will set up Hardhat project, Open up a terminal and execute these commands
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Hardhat is an Ethereum development environment and framework designed for full s
   ```bash
   mkdir Whitelist-Dapp
   cd Whitelist-Dapp
+  
   mkdir hardhat-tutorial
   cd hardhat-tutorial
   npm init --yes

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build the smart contract we will be using [Hardhat](https://hardhat.org/).
 Hardhat is an Ethereum development environment and framework designed for full stack development in Solidity. In simple words you can write your smart contract, deploy them, run tests, and debug your code.
 
 - First, you need to create a Whitelist-Daap folder where the Hardhat project and your Next.js app will later go
-- Then, in that folder, you will set up Hardhat project, Open up a terminal and execute these commands
+- Then, in Whitelist-Daap folder, you will set up Hardhat project, Open up a terminal and execute these commands
 
   ```bash
   mkdir Whitelist-Dapp


### PR DESCRIPTION
It might be a good idea to have instructions to create a Whitelist-Dapp folder right at the start of the project. That might be easier than moving folders around after the fact. 

- I added some instructions for adding the Whitelist-Dapp in the terminal 
- Also edited some text to mention the creation of that folder in the instructions above 
- I also edited the text that I wrote so it can be more clear 