### PR TITLE
Wrong Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Lets start building 🚀
 ## Prefer a Video?
 If you would rather learn from a video, we have a recording available of this tutorial on our YouTube. Watch the video by clicking on the screenshot below, or go ahead and read the tutorial!
 [![Whitelist dApp Part-1](https://i.imgur.com/QsVxGLq.png)](https://www.youtube.com/watch?v=eSS0vZ7rqpU&t=4757s "Whitelist dApp Tutorial")
-[![Whitelist dApp Part-2](https://i.imgur.com/084i0Sp.png)](https://www.youtube.com/watch?v=aqxAWLi6UMA "Whitelist dApp Tutorial")
+[![Whitelist dApp Part-2](https://i.imgur.com/084i0Sp.png)](https://www.youtube.com/watch?v=iMOAUkL09pU "Whitelist dApp Tutorial")
 ## Build
 
 ### Smart Contract


### PR DESCRIPTION
The second image was linking to the Freshman Dapp Tutorial, instead of the second part of the Whitelist Dapp. I updated the link to fix this.